### PR TITLE
io/nativefilestream.cpp: proper catchiofailure.h include

### DIFF
--- a/io/nativefilestream.cpp
+++ b/io/nativefilestream.cpp
@@ -1,7 +1,7 @@
 #include "./nativefilestream.h"
 
 #ifdef PLATFORM_MINGW
-# include <c++utilities/io/catchiofailure.h>
+# include "catchiofailure.h"
 # include <windows.h>
 # include <fcntl.h>
 # include <sys/stat.h>


### PR DESCRIPTION
1. Using <> makes no sense if cpp-utilities is being built for first time

2. Again, search in &lt;prefix&gt;/c++utilities/io makes no sense if cpp-utilities is
   being built for first time