### PR TITLE
catchiofailure.cpp: "_GLIBCXX_USE_CXX11_ABI" redefined

### DIFF
--- a/io/catchiofailure.cpp
+++ b/io/catchiofailure.cpp
@@ -1,12 +1,12 @@
-// include libstd++ specific header <bits/c++config.h> containing _GLIBCXX_RELEASE
+#define _GLIBCXX_USE_CXX11_ABI 0
+// include libstd++ specific header <bits/c++config.h> containing __GLIBCXX__
 // without including ios already (must be included after setting _GLIBCXX_USE_CXX11_ABI)
-#include <cctype>
+#include <cstddef>
 
 // ensure the old ABI is used under libstd++ < 7 and the new ABI under libstd++ >= 7
-#if defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE >= 7
+#if __GLIBCXX__ >= 20170502
+#undef _GLIBCXX_USE_CXX11_ABI
 #define _GLIBCXX_USE_CXX11_ABI 1
-#else
-#define _GLIBCXX_USE_CXX11_ABI 0
 #endif
 
 #include "./catchiofailure.h"


### PR DESCRIPTION

~~~c
/var/cache/glade/cpp-utilities/io/catchiofailure.cpp:9:0: warning:
"_GLIBCXX_USE_CXX11_ABI" redefined
 #define _GLIBCXX_USE_CXX11_ABI 0
 ^
In file included from
/usr/lib/gcc/x86_64-w64-mingw32/5.4.0/include/c++/cctype:41:0, from
/var/cache/glade/cpp-utilities/io/catchiofailure.cpp:3:
/usr/lib/gcc/x86_64-w64-mingw32/5.4.0/include/c++/x86_64-w64-mingw32/bits/
c++config.h:212:0:
note: this is the location of the previous definition
 # define _GLIBCXX_USE_CXX11_ABI 1
 ^
~~~

~~~
2625f82e49214bce656c8deb8cc40a913f39a3ae is the first bad commit
commit 2625f82e49214bce656c8deb8cc40a913f39a3ae
Author: Martchus <martchus@gmx.net>
Date:   Thu Jun 1 11:29:33 2017 +0200

    ios_base::failure workaround: Ensure c++config.h is included
~~~

2625f82 is the culprit