### PR TITLE
commandlineutils.cpp: correct rows and columns

### DIFF
--- a/application/commandlineutils.cpp
+++ b/application/commandlineutils.cpp
@@ -53,10 +53,10 @@ TerminalSize determineTerminalSize()
     if (const HANDLE stdHandle = GetStdHandle(STD_OUTPUT_HANDLE)) {
         GetConsoleScreenBufferInfo(stdHandle, &consoleBufferInfo);
         if (consoleBufferInfo.dwSize.X > 0) {
-            size.rows = static_cast<unsigned short>(consoleBufferInfo.dwSize.X);
+            size.columns = static_cast<unsigned short>(consoleBufferInfo.dwSize.X);
         }
         if (consoleBufferInfo.dwSize.Y > 0) {
-            size.columns = static_cast<unsigned short>(consoleBufferInfo.dwSize.Y);
+            size.rows = static_cast<unsigned short>(consoleBufferInfo.dwSize.Y);
         }
     }
 #endif


### PR DESCRIPTION
From here:

http://docs.microsoft.com/windows/console/coord-str

- X is columns
- Y is rows

currently that is reversed with the codebase