### PR TITLE
Fix building with Xcode

### DIFF
--- a/cmake/modules/BasicConfig.cmake
+++ b/cmake/modules/BasicConfig.cmake
@@ -175,6 +175,7 @@ if (META_FEATURES_FOR_COMPILER_DETECTION_HEADER)
                                     COMPILERS
                                     GNU
                                     Clang
+                                    AppleClang
                                     FEATURES
                                     ${META_FEATURES_FOR_COMPILER_DETECTION_HEADER})
 endif ()


### PR DESCRIPTION
With this additional line, I can build cpp-utilities, qtutilities and syncthingtray on macOS.

Tested environment: macOS 10.14.5, Xcode 11 beta 3
Test results: syncthingtray can be launched from the terminal and connect to the local syncthing server.

