### PR TITLE
Fix building on Mac OS X/macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
 
+project(c++utilities)
+
 # add project files
 set(HEADER_FILES
     application/argumentparser.h


### PR DESCRIPTION
Without project(), compiler flags like -std=gnu++17 are not applied
for non-Apple clang on Mac OS X/macOS.

For a more detailed explanation, see the commit message for a similar case - https://github.com/macports/macports-ports/commit/98445d69fc13be9c968abe4c597de8324b0ceee6.

Also, according to CMake document [1]:

> The top-level CMakeLists.txt file for a project must contain a literal, direct call to the project() command; loading one through the include() command is not sufficient.

That explains why the project() command in cmake/modules/BasicConfig.cmake does not always work.

[1] https://cmake.org/cmake/help/latest/command/project.html#command:project