### PR TITLE
Fix use of `sendfile()` on 32-bit systems

### DIFF
--- a/io/copy.h
+++ b/io/copy.h
@@ -155,7 +155,8 @@ void CopyHelper<bufferSize>::callbackCopy(NativeFileStream &input, NativeFileStr
         output.flush();
         const auto totalBytes = static_cast<std::streamoff>(count);
         while (count) {
-            const auto bytesCopied = ::sendfile64(output.fileDescriptor(), input.fileDescriptor(), nullptr, std::min(count, bufferSize));
+            const auto bytesToCopy = static_cast<std::size_t>(std::min(count, static_cast<std::uint64_t>(bufferSize)));
+            const auto bytesCopied = ::sendfile64(output.fileDescriptor(), input.fileDescriptor(), nullptr, bytesToCopy);
             if (bytesCopied < 0) {
                 throw std::ios_base::failure(argsToString("sendfile64() failed: ", std::strerror(errno)));
             }


### PR DESCRIPTION
`std::min(count, bufferSize)` fails to compile when `bufferSize` is a 32-bit unsigned value, at least with GCC 12, because the STL can't find a template for `std::min` that will compare `std::uint64_t` to `unsigned int`. This is fixed by forcing the comparison for 64-bit types, then casting back down to the `std::size_t` expected by `sendfile64`. The down-cast can never overflow because the argument is always guaranteed to be no larger than the maximum representable size of the `std::size_t bufferSize` argument, so this should always be safe.